### PR TITLE
Add scenario for health affected by both Inbound and Outbound traffic

### DIFF
--- a/error-rates/alpha.yaml
+++ b/error-rates/alpha.yaml
@@ -151,6 +151,124 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: f-client
+spec:
+  selector:
+    matchLabels:
+      app: f-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: f-client
+        version: v1
+    spec:
+      containers:
+        - name: f-client
+          image: kiali/demo_error_rates_client:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: "http://v-server.alpha:8888/status"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: v-server
+spec:
+  selector:
+    matchLabels:
+      app: v-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: v-server
+        version: v1
+    spec:
+      containers:
+        - name: v-server
+          image: kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,10"
+            - name: SERVER_URL
+              value: "http://w-server.alpha:8888/status"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: v-server
+  labels:
+    app: v-server
+spec:
+  ports:
+    - name: http
+      port: 8888
+  selector:
+    app: v-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: w-server
+spec:
+  selector:
+    matchLabels:
+      app: w-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: w-server
+        version: v1
+    spec:
+      containers:
+        - name: w-server
+          image: kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "503,5;200,5"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: w-server
+  labels:
+    app: w-server
+spec:
+  ports:
+    - name: http
+      port: 8888
+  selector:
+    app: w-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: x-server
 spec:
   selector:

--- a/error-rates/beta.yaml
+++ b/error-rates/beta.yaml
@@ -147,6 +147,124 @@ spec:
           env:
             - name: SERVER_URL
               value: "http://z-server.beta:8888/status"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: f-client
+spec:
+  selector:
+    matchLabels:
+      app: f-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: f-client
+        version: v1
+    spec:
+      containers:
+        - name: f-client
+          image: kiali/demo_error_rates_client:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: "http://v-server.alpha:8888/status"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: v-server
+spec:
+  selector:
+    matchLabels:
+      app: v-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: v-server
+        version: v1
+    spec:
+      containers:
+        - name: v-server
+          image: kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,10"
+          env:
+            - name: SERVER_URL
+              value: "http://w-server.alpha:8888/status"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: v-server
+  labels:
+    app: v-server
+spec:
+  ports:
+    - name: http
+      port: 8888
+  selector:
+    app: v-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: w-server
+spec:
+  selector:
+    matchLabels:
+      app: w-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: w-server
+        version: v1
+    spec:
+      containers:
+        - name: w-server
+          image: kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "503,5;200,5"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: w-server
+  labels:
+    app: w-server
+spec:
+  ports:
+    - name: http
+      port: 8888
+  selector:
+    app: w-server
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Add scenario for health affected by both Inbound and Outbound traffi by adding:

   client-f -> server-v -> server-w

This adds some support for a server to also be a client.   It would require new server container be published.

Related to https://github.com/kiali/kiali/issues/3194