### PR TITLE
Add ServiceEntry cases for Electronic Shop demo

### DIFF
--- a/electronic-shop/README.adoc
+++ b/electronic-shop/README.adoc
@@ -51,7 +51,7 @@ In a first iteration, all services have deployed a first version like it's shown
 
 image:doc/Kiali-ElectronicShop-v1.png[Design v1]
 
-In a next step we are going to deploy new versions of the Music service with different behaviour:
+In the next step we are going to deploy new versions of the Music service with different behaviour:
 
 [source,yaml]
 ----
@@ -61,4 +61,21 @@ kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/
 
 image:doc/Kiali-ElectronicShop-Music-v2-v3.png[Design v2 v3]
 
+Once evaluated new version of the Music service, we can deploy new versions for Games and Bookstore service using external services mapped in the Mesh using ServiceEntries.
+
+For Games service:
+
+[source,yaml]
+----
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/games-service-entry.yaml) -n electronic-shop
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/games-v2.yaml) -n electronic-shop
+----
+
+For Bookstore service:
+
+[source,yaml]
+----
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/bookstore-service-entry.yaml) -n electronic-shop
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/bookstore-v2.yaml) -n electronic-shop
+----
 

--- a/electronic-shop/bookstore-service-entry.yaml
+++ b/electronic-shop/bookstore-service-entry.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: www-bookdepository-com
+spec:
+  hosts:
+    - www.bookdepository.com
+  ports:
+    - number: 80
+      name: http-port
+      protocol: HTTP
+      targetPort: 443
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: NONE
+  location: MESH_EXTERNAL

--- a/electronic-shop/bookstore-v2.yaml
+++ b/electronic-shop/bookstore-v2.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookstore-v2
+spec:
+  selector:
+    matchLabels:
+      app: bookstore
+      version: v2
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: bookstore
+        version: v2
+    spec:
+      containers:
+        - name: bookstore
+          image: kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,8;201,1;202,1"
+            - name: SERVER_NAME
+              value: "bookstore-v2"
+            - name: SERVER_URL
+              value: "http://www.bookdepository.com"

--- a/electronic-shop/games-service-entry.yaml
+++ b/electronic-shop/games-service-entry.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: zone-msn-com
+spec:
+  hosts:
+    - zone.msn.com
+  ports:
+    - number: 80
+      name: http-port
+      protocol: HTTP
+      targetPort: 443
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: NONE
+  location: MESH_EXTERNAL

--- a/electronic-shop/games-v2.yaml
+++ b/electronic-shop/games-v2.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: games-v2
+spec:
+  selector:
+    matchLabels:
+      app: games
+      version: v2
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: games
+        version: v2
+    spec:
+      containers:
+        - name: games
+          image: kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,8;201,1;202,1"
+            - name: SEVER_NAME
+              value: "games-v2"
+            - name: SERVER_URL
+              value: "http://zone.msn.com/en-us/home"


### PR DESCRIPTION
I've extended the Electronic Shop demo as a working example for new Iter8 and Kiali scenarios.

![image](https://user-images.githubusercontent.com/1662329/100131249-16eb1d00-2e84-11eb-89c1-3711b103e919.png)

From Kiali we want to extend some management use cases using Egress traffic and also these examples provide workloads with customized errors rate that can be used to evaluate Iter8 experiments.