### PR TITLE
Extend tracing config on workloads

### DIFF
--- a/travels/open.sh
+++ b/travels/open.sh
@@ -7,6 +7,6 @@ set -e
 # Windows users can use "cmd" command
 # Otherwise, the check is just to confirm you can access addons from your browser
 
-xdg-open http://localhost:8080 &
+xdg-open http://localhost:18080 &
 
-kubectl port-forward svc/control 8080:8080 -n travel-control
+kubectl port-forward svc/control 18080:8080 -n travel-control

--- a/travels/travel_agency.yaml
+++ b/travels/travel_agency.yaml
@@ -93,6 +93,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: cars
         version: v1
@@ -156,6 +174,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: discounts
         version: v1
@@ -206,6 +242,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: flights
         version: v1
@@ -269,6 +323,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: hotels
         version: v1
@@ -395,6 +467,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: travels
         version: v1

--- a/travels/travel_portal.yaml
+++ b/travels/travel_portal.yaml
@@ -12,6 +12,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: voyages
         version: v1
@@ -63,6 +81,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: viaggi
         version: v1
@@ -114,6 +150,24 @@ spec:
     metadata:
       annotations:
         readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
       labels:
         app: travels
         version: v1


### PR DESCRIPTION
This PR uses the Istio feature to extend tracing config from a workload with the intention to add specific application info into the observability signals.

The rationale from here is:
- One of the main features of Istio Traffic Shifting is Request Routing.
- Request Routing depends on info that is provided by App.
- Simple things like "what headers are used between applications that I didn't code" sound simple but it's not, it's a problem when you need that info to setup Tasks.
- This info is not collected in the telemetry, but I think tracing is the right place to populate it.

So, my goal from here is to built a story and thinking in more scenarios to use it in Kiali:
- A first one is a manual inspection, then user would be able to use this info for Request Routing.
- Kiali has started to add functionality around annotations in the ServiceMesh context (i.e. sidecar injection on workloads), also there are some work in progress to add Kiali Health Config info as an annotation, so, perhaps in the future a task could be to add an annotation to populate in tracing information like this ? (Again, I'm limiting the scope to the proxy, I know user can connect directly with Jaeger, but I set up this in the Istio/ServiceMesh context first).

As a result this info is available in the tags:
![image](https://user-images.githubusercontent.com/1662329/100903166-df085900-34c5-11eb-8b89-17c38f6ce071.png)

I put several reviewers for this PR, not only to check the code which is quite simple but to share the potential of this direction as well as I see a lot of sinergies with the work you are doing in several areas (tracing correlation, custom telemetry, health config, workload annotations, etc).

No next action planned, but just giving some context about this.