### PR TITLE
Add travels v2/v3 and portal loadbalancer

### DIFF
--- a/travels/build.sh
+++ b/travels/build.sh
@@ -30,6 +30,13 @@ cd ..
 
 ${DORP} build -t ${DOCKER_TRAVEL_PORTAL_TAG} docker/travel_portal
 
+## Travel LoadBalancer
+
+DOCKER_TRAVEL_LOADBALANCER=kiali/demo_travels_loadbalancer
+DOCKER_TRAVEL_LOADBALANCER_TAG=${DOCKER_TRAVEL_LOADBALANCER}:${DOCKER_VERSION}
+
+${DORP} build -t ${DOCKER_TRAVEL_LOADBALANCER_TAG} docker/travel_loadbalancer
+
 ## MySQL
 
 DOCKER_TRAVEL_MYSQL=kiali/demo_travels_mysqldb
@@ -112,6 +119,7 @@ ${DORP} build -t ${DOCKER_TRAVEL_TRAVELS_TAG} docker/travel_agency/travels
 ${DORP} login docker.io
 ${DORP} push ${DOCKER_TRAVEL_CONTROL_TAG}
 ${DORP} push ${DOCKER_TRAVEL_PORTAL_TAG}
+${DORP} push ${DOCKER_TRAVEL_LOADBALANCER_TAG}
 ${DORP} push ${DOCKER_TRAVEL_MYSQL_TAG}
 ${DORP} push ${DOCKER_TRAVEL_CARS_TAG}
 ${DORP} push ${DOCKER_TRAVEL_DISCOUNTS_TAG}

--- a/travels/docker/travel_loadbalancer/Dockerfile
+++ b/travels/docker/travel_loadbalancer/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/fortio/fortio:1.11.4 as fortio
+FROM centos:centos7
+
+LABEL maintainer="ponce.ballesteros@gmail.com"
+
+ENV TRAVEL_HOME=/opt/travel_loadbalancer \
+    PATH=$TRAVEL_HOME:$PATH
+
+WORKDIR $TRAVEL_HOME
+
+COPY travel_loadbalancer.sh $TRAVEL_HOME/
+COPY --from=fortio /usr/bin/fortio /usr/bin/fortio
+
+RUN chmod +x $TRAVEL_HOME/travel_loadbalancer.sh
+ENTRYPOINT ["/opt/travel_loadbalancer/travel_loadbalancer.sh"]

--- a/travels/docker/travel_loadbalancer/travel_loadbalancer.sh
+++ b/travels/docker/travel_loadbalancer/travel_loadbalancer.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CONNECTIONS=${CONNECTIONS:-10}
+NUMCALLS=${NUMCALLS:-20}
+RATE=${RATE:-0}
+SLEEP=${SLEEP:-5}
+
+echo "Travel LoadBalancer Configuration"
+echo "================================================"
+echo "CONNECTIONS=${CONNECTIONS}"
+echo "NUMCALLS=${NUMCALLS}"
+echo "RATE=${RATE}"
+echo "SLEEP=${SLEEP}"
+echo "TRAVELS_AGENCY_SERVICE=${TRAVELS_AGENCY_SERVICE}"
+echo "================================================"
+
+if [ -z "${TRAVELS_AGENCY_SERVICE}" ]
+then
+    echo "TRAVELS_AGENCY_SERVICE must be non empty"
+    exit 1
+fi
+
+while true
+do
+    NOW=$(date +"%Y/%m/%d_%H:%M:%S")
+    echo "[${NOW}][Sleep ${SLEEP}] /usr/bin/fortio load -c ${CONNECTIONS} -qps ${RATE} -n ${NUMCALLS} -loglevel Warning ${TRAVELS_AGENCY_SERVICE}"
+    /usr/bin/fortio load -c ${CONNECTIONS} -qps ${RATE} -n ${NUMCALLS} -loglevel Warning "${TRAVELS_AGENCY_SERVICE}/travels"
+    sleep ${SLEEP}
+done

--- a/travels/travel_loadbalancer.yaml
+++ b/travels/travel_loadbalancer.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadbalancer
+spec:
+  selector:
+    matchLabels:
+      app: loadbalancer
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: loadbalancer
+        version: v1
+    spec:
+      containers:
+        - name: loadbalancer
+          image: kiali/demo_travels_loadbalancer:v1
+          imagePullPolicy: Always
+          securityContext:
+            privileged: false
+          env:
+            - name: CONNECTIONS
+              value: "50"
+            - name: NUMCALLS
+              value: "20"
+            - name: RATE
+              value: "0"
+            - name: SLEEP
+              value: "5"
+            - name: TRAVELS_AGENCY_SERVICE
+              value: "http://travels.travel-agency:8000"

--- a/travels/travels-v2.yaml
+++ b/travels/travels-v2.yaml
@@ -1,0 +1,59 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: travels-v2
+spec:
+  selector:
+    matchLabels:
+      app: travels
+      version: v2
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
+      labels:
+        app: travels
+        version: v2
+    spec:
+      containers:
+        - name: travels
+          image: kiali/demo_travels_travels:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          securityContext:
+            privileged: false
+          env:
+            - name: CURRENT_SERVICE
+              value: "travels"
+            - name: CURRENT_VERSION
+              value: "v2"
+            - name: LISTEN_ADDRESS
+              value: ":8000"
+            - name: FLIGHTS_SERVICE
+              value: "http://flights.travel-agency:8000"
+            - name: HOTELS_SERVICE
+              value: "http://hotels.travel-agency:8000"
+            - name: CARS_SERVICE
+              value: "http://cars.travel-agency:8000"
+            - name: INSURANCES_SERVICE
+              value: "http://insurances.travel-agency:8000"

--- a/travels/travels-v3.yaml
+++ b/travels/travels-v3.yaml
@@ -1,0 +1,59 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: travels-v3
+spec:
+  selector:
+    matchLabels:
+      app: travels
+      version: v3
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.istio-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
+      labels:
+        app: travels
+        version: v3
+    spec:
+      containers:
+        - name: travels
+          image: kiali/demo_travels_travels:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          securityContext:
+            privileged: false
+          env:
+            - name: CURRENT_SERVICE
+              value: "travels"
+            - name: CURRENT_VERSION
+              value: "v3"
+            - name: LISTEN_ADDRESS
+              value: ":8000"
+            - name: FLIGHTS_SERVICE
+              value: "http://flights.travel-agency:8000"
+            - name: HOTELS_SERVICE
+              value: "http://hotels.travel-agency:8000"
+            - name: CARS_SERVICE
+              value: "http://cars.travel-agency:8000"
+            - name: INSURANCES_SERVICE
+              value: "http://insurances.travel-agency:8000"


### PR DESCRIPTION
As part of the demo material used for https://github.com/kiali/kiali/issues/3488 I've introduced some versioning in the travels service and a loadbalancer workload (suited to the travel-portal namespace) for better simulate CircuitBreaker scenarios.

