### PR TITLE
New optional step to federate a tcp connection (cars to mysqldb)

### DIFF
--- a/federated-travels/README.md
+++ b/federated-travels/README.md
@@ -120,6 +120,13 @@ To obtain the kubeadmin user credentials, execute:
 crc console --credentials
 ```
 
+As an optional step, the following configuration will load balance the outcoming traffic from *cars* service including the *cars* workload deployed in *west* mesh, which in turn will consume the MySQL database from *east* mesh:
+
+```bash
+oc apply -n east-mesh-system -f https://raw.githubusercontent.com/kiali/demos/master/federated-travels/east/east-federation-opt.yaml
+oc apply -n west-mesh-system -f https://raw.githubusercontent.com/kiali/demos/master/federated-travels/west/west-federation-opt.yaml
+```
+
 ## Cleanup
 
 Delete all namespaces:

--- a/federated-travels/east/east-federation-opt.yaml
+++ b/federated-travels/east/east-federation-opt.yaml
@@ -1,0 +1,33 @@
+---
+kind: ImportedServiceSet
+apiVersion: federation.maistra.io/v1
+metadata:
+  name: west-mesh
+  namespace: east-mesh-system
+spec:
+  importRules:
+  - type: NameSelector
+    nameSelector:
+      importAsLocal: false
+      namespace: travel-agency
+      name: discounts
+  - type: NameSelector
+    nameSelector:
+      importAsLocal: false
+      namespace: travel-agency
+      name: cars
+---
+kind: ExportedServiceSet
+apiVersion: federation.maistra.io/v1
+metadata:
+  name: west-mesh
+  namespace: east-mesh-system
+spec:
+  exportRules:  
+  - type: NameSelector
+    nameSelector:
+      namespace: east-travel-agency
+      name: mysqldb
+      alias:
+        namespace: travel-agency
+        name: mysqldb

--- a/federated-travels/east/east-federation.yaml
+++ b/federated-travels/east/east-federation.yaml
@@ -34,3 +34,20 @@ spec:
       importAsLocal: false
       namespace: travel-agency
       name: discounts
+---
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: discounts
+  namespace: east-mesh-system
+spec:
+  hosts:
+  - discounts.east-travel-agency.svc.cluster.local
+  http:
+  - route:
+      - destination:
+          host: discounts.travel-agency.svc.west-mesh-imports.local
+        weight: 50
+      - destination:
+          host: discounts.east-travel-agency.svc.cluster.local
+        weight: 50

--- a/federated-travels/east/east-federation.yaml
+++ b/federated-travels/east/east-federation.yaml
@@ -34,20 +34,3 @@ spec:
       importAsLocal: false
       namespace: travel-agency
       name: discounts
----
-kind: VirtualService
-apiVersion: networking.istio.io/v1alpha3
-metadata:
-  name: discounts
-  namespace: east-mesh-system
-spec:
-  hosts:
-  - discounts.east-travel-agency.svc.cluster.local
-  http:
-  - route:
-      - destination:
-          host: discounts.travel-agency.svc.west-mesh-imports.local
-        weight: 50
-      - destination:
-          host: discounts.east-travel-agency.svc.cluster.local
-        weight: 50

--- a/federated-travels/east/east-travel-agency-opt.yaml
+++ b/federated-travels/east/east-travel-agency-opt.yaml
@@ -1,0 +1,17 @@
+---
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: cars
+  namespace: east-travel-agency
+spec:
+  hosts:
+  - cars.east-travel-agency.svc.cluster.local
+  http:
+  - route:
+      - destination:
+          host: cars.travel-agency.svc.west-mesh-imports.local
+        weight: 50
+      - destination:
+          host: cars.east-travel-agency.svc.cluster.local
+        weight: 50

--- a/federated-travels/east/east-travel-agency.yaml
+++ b/federated-travels/east/east-travel-agency.yaml
@@ -533,20 +533,3 @@ spec:
       port: 8000
   selector:
     app: travels
----
-kind: VirtualService
-apiVersion: networking.istio.io/v1alpha3
-metadata:
-  name: discounts
-  namespace: east-travel-agency
-spec:
-  hosts:
-    - discounts.east-travel-agency.svc.cluster.local
-  http:
-    - route:
-        - destination:
-            host: discounts.travel-agency.svc.west-mesh-imports.local
-          weight: 50
-        - destination:
-            host: discounts.east-travel-agency.svc.cluster.local
-          weight: 50

--- a/federated-travels/east/east-travel-agency.yaml
+++ b/federated-travels/east/east-travel-agency.yaml
@@ -533,3 +533,20 @@ spec:
       port: 8000
   selector:
     app: travels
+---
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: discounts
+  namespace: east-travel-agency
+spec:
+  hosts:
+  - discounts.east-travel-agency.svc.cluster.local
+  http:
+  - route:
+      - destination:
+          host: discounts.travel-agency.svc.west-mesh-imports.local
+        weight: 50
+      - destination:
+          host: discounts.east-travel-agency.svc.cluster.local
+        weight: 50

--- a/federated-travels/west/west-federation-opt.yaml
+++ b/federated-travels/west/west-federation-opt.yaml
@@ -1,0 +1,35 @@
+---
+kind: ExportedServiceSet
+apiVersion: federation.maistra.io/v1
+metadata:
+  name: east-mesh
+  namespace: west-mesh-system
+spec:
+  exportRules:  
+  - type: NameSelector
+    nameSelector:
+      namespace: west-travel-agency
+      name: discounts
+      alias:
+        namespace: travel-agency
+        name: discounts
+  - type: NameSelector
+    nameSelector:
+      namespace: west-travel-agency
+      name: cars
+      alias:
+        namespace: travel-agency
+        name: cars        
+---
+kind: ImportedServiceSet
+apiVersion: federation.maistra.io/v1
+metadata:
+  name: east-mesh
+  namespace: west-mesh-system
+spec:
+  importRules:
+  - type: NameSelector
+    nameSelector:
+      importAsLocal: false
+      namespace: travel-agency
+      name: mysqldb

--- a/federated-travels/west/west-travel-agency.yaml
+++ b/federated-travels/west/west-travel-agency.yaml
@@ -81,3 +81,96 @@ spec:
   selector:
     app: discounts
 ---
+##################################################################################################
+# Cars services
+##################################################################################################
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cars-v1
+spec:
+  selector:
+    matchLabels:
+      app: cars
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+        proxy.istio.io/config: |
+          tracing:
+            zipkin:
+              address: zipkin.west-mesh-system:9411
+            sampling: 10
+            custom_tags:
+              http.header.portal:
+                header:
+                  name: portal
+              http.header.device:
+                header:
+                  name: device
+              http.header.user:
+                header:
+                  name: user
+              http.header.travel:
+                header:
+                  name: travel
+      labels:
+        app: cars
+        version: v1
+    spec:
+      containers:
+        - name: cars
+          image: quay.io/kiali/demo_travels_cars:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          securityContext:
+            privileged: false
+          env:
+            - name: CURRENT_SERVICE
+              value: "cars"
+            - name: CURRENT_VERSION
+              value: "v1"
+            - name: LISTEN_ADDRESS
+              value: ":8000"
+            - name: DISCOUNTS_SERVICE
+              value: "http://discounts.west-travel-agency:8000"
+            - name: MYSQL_SERVICE
+              value: "mysqldb.travel-agency.svc.east-mesh-imports.local:3306"
+            - name: MYSQL_USER
+              value: "root"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-credentials
+                  key: rootpasswd
+            - name: MYSQL_DATABASE
+              value: "test"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cars
+  labels:
+    app: cars
+spec:
+  ports:
+    - name: http
+      port: 8000
+  selector:
+    app: cars
+---
+##################################################################################################
+# Mysql db services
+# credentials: root/password
+##################################################################################################
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-credentials
+type: Opaque
+data:
+  rootpasswd: cGFzc3dvcmQ=


### PR DESCRIPTION
This PR adds to the federated travels demo a way to configure the mesh so there is federated tcp traffic to show in Kiali.

This example raised based on a comment from an user indicating that tcp traffic visualization differs from http, which is true, so this example will help us to identify why that is.