### PR TITLE
Use latest operator versions

### DIFF
--- a/federated-travels/ossm-subs.yaml
+++ b/federated-travels/ossm-subs.yaml
@@ -10,7 +10,6 @@ spec:
   name: kiali-ossm
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kiali-operator.v1.36.5
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -23,7 +22,6 @@ spec:
   name: jaeger-product
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: jaeger-operator.v1.24.1
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -36,4 +34,3 @@ spec:
   name: servicemeshoperator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: servicemeshoperator.v2.1.0


### PR DESCRIPTION
There has been an update of operators, so, removing from the ossm script to take the latest.

A workaround could be to install the operators through the UI.