### PR TITLE
Add an egress example in music-v4 workload

### DIFF
--- a/electronic-shop/README.adoc
+++ b/electronic-shop/README.adoc
@@ -90,3 +90,14 @@ In this step we are going to define a Gateway to transparently route the externa
 kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/bookstore-egress-service-entry.yaml) -n electronic-shop
 ----
 
+== Multiple destinations using Egress gateways
+
+In real scenarios, cluster workloads may not have direct access to Internet, so any external call should be routed using egress.
+
+In this step we are going to demonstrate how egress gateways can manage multiple service entries. We will create a new music-v4 workload that will connect to the edition.cnn.com external service.
+
+[source,yaml]
+----
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/music-egress-service-entry.yaml) -n electronic-shop
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/electronic-shop/music-v4.yaml) -n electronic-shop
+----

--- a/electronic-shop/music-egress-service-entry.yaml
+++ b/electronic-shop/music-egress-service-entry.yaml
@@ -1,0 +1,100 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: edition-cnn-com
+spec:
+  hosts:
+    - edition.cnn.com
+  ports:
+    - number: 80
+      name: http-port
+      protocol: HTTP
+      targetPort: 443
+    - number: 443
+      name: https
+      protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gw-cnn
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+    - port:
+        number: 80
+        name: https-port-for-tls-origination
+        protocol: HTTPS
+      hosts:
+        - edition.cnn.com
+      tls:
+        mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: dr-cnn
+spec:
+  host: istio-egressgateway.istio-system.svc.cluster.local
+  subsets:
+    - name: cnn
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 80
+          tls:
+            mode: ISTIO_MUTUAL
+            sni: edition.cnn.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: vs-cnn
+spec:
+  hosts:
+    - edition.cnn.com
+  gateways:
+    - gw-cnn
+    - mesh
+  http:
+    - match:
+        - gateways:
+            - mesh
+          port: 80
+      route:
+        - destination:
+            host: istio-egressgateway.istio-system.svc.cluster.local
+            subset: cnn
+            port:
+              number: 80
+          weight: 100
+    - match:
+        - gateways:
+            - gw-cnn
+          port: 80
+      route:
+        - destination:
+            host: edition.cnn.com
+            port:
+              number: 443
+          weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: originate-tls-for-music
+spec:
+  host: edition.cnn.com
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+    portLevelSettings:
+      - port:
+          number: 443
+        tls:
+          mode: SIMPLE # initiates HTTPS for connections to edition.cnn.com

--- a/electronic-shop/music-v4.yaml
+++ b/electronic-shop/music-v4.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: music-v4
+spec:
+  selector:
+    matchLabels:
+      app: music
+      version: v4
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: music
+        version: v4
+    spec:
+      containers:
+        - name: bookstore
+          image: quay.io/kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,8;201,1;202,1"
+            - name: SERVER_NAME
+              value: "music-v4"
+            - name: SERVER_URL
+              value: "http://edition.cnn.com"


### PR DESCRIPTION
An addition to the "electronic-shop" demo to have a case where multiple destinations are routed through the egress gateway.

![image](https://user-images.githubusercontent.com/1662329/144387755-43d8bdd0-56de-41cf-8755-c2728023654a.png)

![image](https://user-images.githubusercontent.com/1662329/144388148-83a77340-75a4-4d76-b8d0-e530fb154a7b.png)
