### PR TITLE
[demos] move -o option to the front of the cmd

### DIFF
--- a/topology-generator/Makefile
+++ b/topology-generator/Makefile
@@ -9,7 +9,7 @@ build-multiarch-binary: build-binary-linux build-binary-darwin build-binary-wind
 # build topogen binary
 build-binary: clean build-ui
 	cp -r ui/build pkg/controller/
-	go build app/topogen.go -o topogen
+	go build -o topogen app/topogen.go
 	rm -rf pkg/controller/build
 
 # build linux topogen binary


### PR DESCRIPTION
required when building with go 1.17.8
unsure what versions of go allow for -o to be at the end, but mine did not. must be up front.