### PR TITLE
[error-rates] Add "gamma" namespace with config but no traffic

### DIFF
--- a/error-rates/README.adoc
+++ b/error-rates/README.adoc
@@ -10,18 +10,21 @@ Additional configurations are needed in a case of installing on https://istio.io
 
 == Quick Start
 
-Create `alpha` and `beta` namespaces. Add `istio-injection` label and deploy demo app.
+Create `alpha`, `beta` and `gamma` namespaces. Add `istio-injection` label and deploy demo app.
 
 [source,yaml]
 ----
 kubectl create namespace alpha
 kubectl create namespace beta
+kubectl create namespace gamma
 
 kubectl label namespace alpha istio-injection=enabled
 kubectl label namespace beta istio-injection=enabled
+kubectl label namespace gamma istio-injection=enabled
 
 kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/alpha.yaml) -n alpha
 kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/beta.yaml) -n beta
+kubectl apply -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/gamma.yaml) -n gamma
 
 ----
 
@@ -39,14 +42,19 @@ Undeploy the example:
 ----
 kubectl delete -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/alpha.yaml) -n alpha
 kubectl delete -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/beta.yaml) -n beta
+kubectl delete -f <(curl -L https://raw.githubusercontent.com/kiali/demos/master/error-rates/beta.yaml) -n gamma
 
 kubectl delete namespace alpha
 kubectl delete namespace beta
+kubectl delete namespace gamma
 ----
 
 == Error Rates Demo Design
 
-This demo creates two namespaces (alpha, and beta) with the same topology of microservices.
+This demo creates three namespaces (alpha, beta and gamma) with the same topology of microservices.
+
+The gamma namespace is not designed to have traffic, only configuration, and can be ignored or used
+for additional testing.  To add traffic edit gamma.yaml and set SERVER_URL env vars as needed.
 
 A namespace will have three servers (x-server, y-server and z-server) that may simulate a predictable error rate.
 

--- a/error-rates/deploy.sh
+++ b/error-rates/deploy.sh
@@ -3,9 +3,12 @@ set -e
 
 kubectl create namespace alpha
 kubectl create namespace beta
+kubectl create namespace gamma
 
 kubectl label namespace alpha istio-injection=enabled
 kubectl label namespace beta istio-injection=enabled
+kubectl label namespace gamma istio-injection=enabled
 
 kubectl apply -f alpha.yaml -n alpha
 kubectl apply -f beta.yaml -n beta
+kubectl apply -f beta.yaml -n gamma

--- a/error-rates/gamma.yaml
+++ b/error-rates/gamma.yaml
@@ -1,0 +1,396 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a-client
+spec:
+  selector:
+    matchLabels:
+      app: a-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: a-client
+        version: v1
+    spec:
+      containers:
+        - name: a
+          image: quay.io/kiali/demo_error_rates_client:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: b-client
+spec:
+  selector:
+    matchLabels:
+      app: b-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: b-client
+        version: v1
+    spec:
+      containers:
+        - name: b-client
+          image: quay.io/kiali/demo_error_rates_client:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: c-client
+spec:
+  selector:
+    matchLabels:
+      app: c-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: c-client
+        version: v1
+    spec:
+      containers:
+        - name: c-client
+          image: quay.io/kiali/demo_error_rates_client:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: d-client
+spec:
+  selector:
+    matchLabels:
+      app: d-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: d-client
+        version: v1
+    spec:
+      containers:
+        - name: d-client
+          image: quay.io/kiali/demo_error_rates_client:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e-client
+spec:
+  selector:
+    matchLabels:
+      app: e-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: e-client
+        version: v1
+    spec:
+      containers:
+        - name: e-client
+          image: quay.io/kiali/demo_error_rates_client:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: f-client
+spec:
+  selector:
+    matchLabels:
+      app: f-client
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: f-client
+        version: v1
+    spec:
+      containers:
+        - name: f-client
+          image: quay.io/kiali/demo_error_rates_client:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: v-server
+spec:
+  selector:
+    matchLabels:
+      app: v-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: v-server
+        version: v1
+    spec:
+      containers:
+        - name: v-server
+          image: quay.io/kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,10"
+            - name: SERVER_URL
+              value: ""
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: v-server
+  labels:
+    app: v-server
+spec:
+  ports:
+    - name: http
+      port: 8899
+  selector:
+    app: v-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: w-server
+spec:
+  selector:
+    matchLabels:
+      app: w-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: w-server
+        version: v1
+    spec:
+      containers:
+        - name: w-server
+          image: quay.io/kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "503,5;200,5"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: w-server
+  labels:
+    app: w-server
+spec:
+  ports:
+    - name: http
+      port: 8899
+  selector:
+    app: w-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: x-server
+spec:
+  selector:
+    matchLabels:
+      app: x-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: x-server
+        version: v1
+    spec:
+      containers:
+        - name: x-server
+          image: quay.io/kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,9;404,1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: x-server
+  labels:
+    app: x-server
+spec:
+  ports:
+    - name: http
+      port: 8899
+  selector:
+    app: x-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: y-server
+spec:
+  selector:
+    matchLabels:
+      app: y-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: y-server
+        version: v1
+    spec:
+      containers:
+        - name: y-server
+          image: quay.io/kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,9;500,1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: y-server
+  labels:
+    app: y-server
+spec:
+  ports:
+    - name: http
+      port: 8899
+  selector:
+    app: y-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: z-server
+spec:
+  selector:
+    matchLabels:
+      app: z-server
+      version: v1
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
+      labels:
+        app: z-server
+        version: v1
+    spec:
+      containers:
+        - name: z-server
+          image: quay.io/kiali/demo_error_rates_server:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8899
+          securityContext:
+            privileged: false
+          env:
+            - name: CODE_REQUESTS
+              value: "200,8;201,1;202,1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: z-server
+  labels:
+    app: z-server
+spec:
+  ports:
+    - name: http
+      port: 8899
+  selector:
+    app: z-server

--- a/error-rates/undeploy.sh
+++ b/error-rates/undeploy.sh
@@ -3,8 +3,10 @@ set -e
 
 kubectl delete -f alpha.yaml -n alpha
 kubectl delete -f beta.yaml -n beta
+kubectl delete -f gamma.yaml -n gamma
 
 kubectl delete namespace alpha
 kubectl delete namespace beta
+kubectl delete namespace gamma
 
 


### PR DESCRIPTION
This is primarily to help with cypress tests that need this scenario, initially to be used to improve  testing for "Show Idle Nodes" Graph Dispay option.

@josunect , this adds another namespace to error_rates but one that doesn't have any traffic.  It's used to improve the idle nodes cypress testing.  So this need to get merged before CI can run successfully on that pending PR. 